### PR TITLE
Fixing typo on pt

### DIFF
--- a/pt.html
+++ b/pt.html
@@ -1633,7 +1633,7 @@ Remember, if your translated word is too big, you can modify the CSS! (especiall
 	indo trabalhar
 </words>
 <words x=335 y=233 w=130 no-bg class="comic_text">
-	antes de dormit
+	antes de dormir
 </words>
 <words x=30 y=320 w=430 h=90 class="text_smaller08">
 	Não importa muito <i>quando</i> você faz isso, contanto que você faça


### PR DESCRIPTION
Fixing the word "dormir" (it doesn't exist word "dormit" in Portuguese). Probably a typo :slightly_smiling_face: 